### PR TITLE
Add requirements file and backend setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ cd <YOUR_PROJECT_NAME>
 # 2. Installeer dependencies
 npm install
 
-# 3. Start de development server
+# 3. Installeer backend packages
+pip install -r requirements.txt
+
+# 4. Start de development server
 npm run dev
 ```
 
@@ -77,8 +80,13 @@ src/
 ### Backend Development
 Zorg dat je Python backend draait op poort 5000 met endpoints:
 - `GET /health` - Health check
-- `POST /generate-xbrl` - XBRL generatie  
+- `POST /generate-xbrl` - XBRL generatie
 - `POST /validate` - XBRL validatie
+
+Installeer de benodigde Python packages met:
+```bash
+pip install -r requirements.txt
+```
 
 ### Frontend Development
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask
+flask-cors
+pyodbc
+requests


### PR DESCRIPTION
## Summary
- document backend dependency installation in README
- add a simple `requirements.txt` for the Python backend

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6868ef1c25f883219e085c95d407565a